### PR TITLE
Replace hardcoded Jellyfin authentication DeviceId to include hostname

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -100,7 +100,7 @@ const authenticate = async (
             Username: body.username,
         },
         headers: {
-            'x-emby-authorization': `MediaBrowser Client="Feishin", Device="${getHostname()}", DeviceId="Feishin", Version="${
+            'x-emby-authorization': `MediaBrowser Client="Feishin", Device="${getHostname()}", DeviceId="Feishin-${getHostname()}", Version="${
                 packageJson.version
             }"`,
         },


### PR DESCRIPTION
Fixes bug preventing two separate users on the same Jellyfin instance from being logged in simultaneously due to conflicting DeviceIds